### PR TITLE
Improve auth provider & address deprecated defaultProps in Modal

### DIFF
--- a/react-app/src/components/Modal.tsx
+++ b/react-app/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 interface modalPropsType {
   open: boolean;
-  onClose: any;
+  onClose: () => void;
   children: React.ReactNode;
   height: number;
   width?: number;
@@ -11,7 +11,7 @@ const Modal = ({
   onClose,
   children,
   height,
-  width,
+  width = 400,
 }: modalPropsType): React.ReactElement => {
   const heightString = height + "px";
   return (
@@ -44,8 +44,5 @@ const Modal = ({
   );
 };
 
-Modal.defaultProps = {
-  width: 400,
-};
 
 export default Modal;

--- a/react-app/src/config/firebase.ts
+++ b/react-app/src/config/firebase.ts
@@ -3,8 +3,8 @@ import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 // import { getAnalytics } from "firebase/analytics";
-//@ts-expect-erroring
-import { getFunctions, connectFunctionsEmulator } from "firebase/functions";
+import { getFunctions } from "firebase/functions";
+import { getAuth } from "firebase/auth";
 
 // TODO: Add SDKs for Firebase products that you want to use
 
@@ -30,5 +30,6 @@ const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
 export const functions = getFunctions(app, "us-east4");
+export const auth = getAuth(app);
 //connectFunctionsEmulator(functions, "127.0.0.1", 5001);
 export default app;


### PR DESCRIPTION
* Fixed a small memory leak in the auth provider caused by not returning the unsubscribe function for `onIdTokenChange` from the  useEffect callback
* Consolidated the auth state in the auth provider into one state object to prevent race conditions
* Removed `any` types from auth provider
* Addressed deprecated defaultProps warning in Modal.tsx