### PR TITLE
Add squarespace dashboard page

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -9,6 +9,7 @@ import BooqableDashboard from "./pages/BooqableDashboardPage";
 import { AuthProvider } from "./auth/AuthProvider";
 import AcuityDashboard from "./pages/AcuityDashboardPage/AcuityDashboardPage";
 import JaneDashboard from "./pages/JaneDashboardPage/JaneDashboardPage";
+import SquarespaceDashboard from "./pages/SquarespaceDashboardPage/SquarespaceDashboardPage";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./config/query";
 import ClientListPage from "./pages/ClientListPage/ClientListPage";
@@ -49,7 +50,6 @@ function App() {
         <BrowserRouter>
           <AuthProvider>
             <ScrollToTop>
-
               <Routes>
                 <Route
                   path="/login"
@@ -82,11 +82,21 @@ function App() {
                 >
                   <Route path="/" element={<HomePage />} />
                   <Route path="/services/jane" element={<JaneDashboard />} />
-                  <Route path="/services/jane/data" element={<JaneDataPage />} />
-                  <Route path="/services/acuity" element={<AcuityDashboard />} />
+                  <Route
+                    path="/services/jane/data"
+                    element={<JaneDataPage />}
+                  />
+                  <Route
+                    path="/services/acuity"
+                    element={<AcuityDashboard />}
+                  />
                   <Route
                     path="/services/booqable"
                     element={<BooqableDashboard />}
+                  />
+                  <Route
+                    path="/services/squarespace"
+                    element={<SquarespaceDashboard />}
                   />
                   <Route path="/clients" element={<ClientListPage />} />
                   <Route

--- a/react-app/src/components/DataTable/DataTable.tsx
+++ b/react-app/src/components/DataTable/DataTable.tsx
@@ -27,6 +27,7 @@ import { Button } from "../ui/button";
 import { ClientTableRow } from "@/pages/ClientListPage/ClientListTableColumns";
 import { useAuth } from "@/auth/AuthProvider";
 import { cn } from "@/lib/utils";
+import { SquarespaceOrder } from "@/services/squarespaceService";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -130,7 +131,9 @@ export function DataTable<TData, TValue>({
               : "flex items-center gap-3 w-full"
           }
         >
-          {(tableType === "clientList" || tableType === "janeData") && (
+          {(tableType === "clientList" ||
+            tableType === "janeData" ||
+            tableType === "squarespaceData") && (
             <div className="flex items-center w-full max-w-sm border bg-bcgw-gray-light p-1.5">
               <input
                 type="text"
@@ -201,13 +204,19 @@ export function DataTable<TData, TValue>({
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => {
-                const client = row.original as ClientTableRow;
+                const client = row.original as
+                  | ClientTableRow
+                  | SquarespaceOrder;
+
+                const rowClickable =
+                  tableType === "clientList" ||
+                  (tableType === "squarespaceData" && client.id);
 
                 return (
                   <TableRow
                     key={row.id}
                     onClick={() => {
-                      if (tableType === "clientList") {
+                      if (rowClickable) {
                         navigate(`/clients/journey/${client.id}`);
                       }
                     }}
@@ -217,21 +226,22 @@ export function DataTable<TData, TValue>({
                       rowClassName,
                     )}
                   >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell
-                        key={cell.id}
-                        className={`${
-                          tableType === "clientList"
-                            ? "cursor-pointer group-hover:bg-[#F5BB4782] group-active:bg-bcgw-yellow-dark transition-colors px-4"
-                            : "px-3"
-                        }`}
-                      >
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
+                    {row.getVisibleCells().map((cell) => {
+                      const cellClass = rowClickable
+                        ? "cursor-pointer group-hover:bg-[#F5BB4782] group-active:bg-bcgw-yellow-dark transition-colors px-4"
+                        : tableType === "squarespaceData"
+                          ? "cursor-not-allowed px-4"
+                          : "px-3";
+
+                      return (
+                        <TableCell key={cell.id} className={cellClass}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      );
+                    })}
                   </TableRow>
                 );
               })

--- a/react-app/src/components/DataTable/DataTable.tsx
+++ b/react-app/src/components/DataTable/DataTable.tsx
@@ -27,7 +27,7 @@ import { Button } from "../ui/button";
 import { ClientTableRow } from "@/pages/ClientListPage/ClientListTableColumns";
 import { useAuth } from "@/auth/AuthProvider";
 import { cn } from "@/lib/utils";
-import { SquarespaceOrder } from "@/services/squarespaceService";
+import { SquarespaceOrder } from "@/pages/SquarespaceDashboardPage/SquarespaceTableColumns";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];

--- a/react-app/src/components/MobileNavigationBar.tsx
+++ b/react-app/src/components/MobileNavigationBar.tsx
@@ -66,7 +66,8 @@ const MobileNavigationBar = () => {
     return (
       location.pathname.includes("/services/jane") ||
       location.pathname.includes("/services/acuity") ||
-      location.pathname.includes("/services/booqable")
+      location.pathname.includes("/services/booqable") ||
+      location.pathname.includes("/services/squarespace")
     );
   };
 

--- a/react-app/src/components/MobileNavigationBar.tsx
+++ b/react-app/src/components/MobileNavigationBar.tsx
@@ -201,6 +201,18 @@ const MobileNavigationBar = () => {
                 >
                   Booqable
                 </NavLink>
+                <NavLink
+                  to="/services/squarespace"
+                  className={({ isActive }) =>
+                    `block px-6 py-3 text-base font-medium ${
+                      isActive
+                        ? "bg-bcgw-yellow-dark"
+                        : "bg-white hover:bg-bcgw-yellow-light"
+                    }`
+                  }
+                >
+                  Squarespace
+                </NavLink>
               </div>
             )}
           </div>

--- a/react-app/src/components/NavigationBar/NavigationBar.tsx
+++ b/react-app/src/components/NavigationBar/NavigationBar.tsx
@@ -48,8 +48,9 @@ const NavigationBar: React.FC<NavigationBarProps> = ({
 
   return (
     <div
-      className={`flex flex-col justify-left h-screen fixed bg-[#F9F8F8] shadow-[4px_4px_4px_0px_rgba(0,_0,_0,_0.25)] transition-all duration-200 ease-in-out ${navBarOpen ? "w-[250px]" : "w-[60px]"
-        }`}
+      className={`flex flex-col justify-left h-screen fixed bg-[#F9F8F8] shadow-[4px_4px_4px_0px_rgba(0,_0,_0,_0.25)] transition-all duration-200 ease-in-out ${
+        navBarOpen ? "w-[250px]" : "w-[60px]"
+      }`}
     >
       <div className="flex flex-col h-full ">
         <div className="flex flex-row justify-between items-center pr-3 pt-1">
@@ -153,6 +154,16 @@ const NavigationBar: React.FC<NavigationBarProps> = ({
                       }
                     >
                       <span className={serviceMargin}>Booqable</span>
+                    </NavLink>
+                  </div>
+                  <div className={serviceStyle}>
+                    <NavLink
+                      to="/services/squarespace"
+                      className={({ isActive }) =>
+                        isActive ? activeStyle : notActiveStyle
+                      }
+                    >
+                      <span className={serviceMargin}>Squarespace</span>
                     </NavLink>
                   </div>
                 </div>

--- a/react-app/src/hooks/queries/useAllSquarespaceOrdersInRangeWithProfiles.ts
+++ b/react-app/src/hooks/queries/useAllSquarespaceOrdersInRangeWithProfiles.ts
@@ -25,7 +25,7 @@ export function useSquarespaceOrdersInRangeWithProfiles(
         const emailToClientMap: Map<string, Client> = new Map();
         for (const client of clients) {
           emailToClientMap.set(client.email, client);
-          for (const assoc of client.associatedClients) {
+          for (const assoc of client.associatedClients ?? []) {
             emailToClientMap.set(assoc.email, client);
           }
         }

--- a/react-app/src/hooks/queries/useAllSquarespaceOrdersInRangeWithProfiles.ts
+++ b/react-app/src/hooks/queries/useAllSquarespaceOrdersInRangeWithProfiles.ts
@@ -1,0 +1,61 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAllClients } from "@/services/clientService";
+import queries from "@/queries";
+import {
+  getAllSquarespaceOrdersInRangeWithProfiles,
+  SquarespaceOrderWithProfile,
+} from "@/services/squarespaceService";
+import { Client } from "@/types/ClientType";
+
+export function useSquarespaceOrdersInRangeWithProfiles(
+  startDate?: string,
+  endDate?: string,
+) {
+  return useQuery<(SquarespaceOrderWithProfile & { client?: Client | null })[]>(
+    {
+      ...queries.squarespaceData.orders(startDate, endDate),
+      queryFn: async (): Promise<
+        (SquarespaceOrderWithProfile & { client?: Client | null })[]
+      > => {
+        const clients = await getAllClients();
+        const orders = await getAllSquarespaceOrdersInRangeWithProfiles(
+          startDate,
+          endDate,
+        );
+        const emailToClientMap: Map<string, Client> = new Map();
+        for (const client of clients) {
+          emailToClientMap.set(client.email, client);
+          for (const assoc of client.associatedClients) {
+            emailToClientMap.set(assoc.email, client);
+          }
+        }
+
+        return orders.map((order) => {
+          const orderEmail =
+            order.customerEmail ?? order.customerProfile?.email;
+
+          const client = orderEmail
+            ? (emailToClientMap.get(orderEmail) ?? null)
+            : null;
+
+          if (
+            order.customerProfile &&
+            !order.customerProfile?.firstName &&
+            client
+          ) {
+            order.customerProfile = {
+              ...order.customerProfile,
+              firstName: client.firstName,
+              lastName: client.lastName,
+            };
+          }
+
+          return {
+            ...order,
+            client,
+          };
+        });
+      },
+    },
+  );
+}

--- a/react-app/src/pages/SquarespaceDashboardPage/SquarespaceDashboardPage.tsx
+++ b/react-app/src/pages/SquarespaceDashboardPage/SquarespaceDashboardPage.tsx
@@ -1,0 +1,88 @@
+import {
+  DateRangePicker,
+  defaultDateRange,
+  defaultPresets,
+} from "@/components/DateRangePicker/DateRangePicker.tsx";
+import { useSquarespaceOrdersInRangeWithProfiles } from "@/hooks/queries/useAllSquarespaceOrdersInRangeWithProfiles.ts";
+import Loading from "@/components/Loading.tsx";
+import { DataTable } from "@/components/DataTable/DataTable.tsx";
+import {
+  SquarespaceOrder,
+  squarespaceColumns,
+} from "./SquarespaceTableColumns.tsx";
+import { DateRange } from "react-day-picker";
+import { useMemo, useState } from "react";
+
+const SquarespaceDashboardPage = () => {
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(
+    defaultDateRange,
+  );
+
+  const {
+    data: squarespaceOrders,
+    isPending,
+    error,
+  } = useSquarespaceOrdersInRangeWithProfiles(
+    dateRange?.from?.toISOString(),
+    dateRange?.to?.toISOString(),
+  );
+
+  const orders: SquarespaceOrder[] = useMemo(
+    () =>
+      squarespaceOrders?.flatMap((order) =>
+        order.lineItems.map((item) => ({
+          name: `${order.customerProfile?.firstName ?? "In-Person Client"} ${order.customerProfile?.lastName ?? ""}`,
+          email: order.customerProfile?.email ?? "N/A",
+          item: `${item.productName} x${item.quantity}`,
+          cost: parseFloat(item.unitPricePaid.value) * item.quantity,
+          date: order.fulfilledOn,
+          channel: `${order.channel === "pos" ? "In-person" : "Online"}`,
+          id: order.client?.id ?? undefined,
+        })),
+      ) ?? [],
+    [squarespaceOrders],
+  );
+
+  return (
+    <>
+      <div className="flex flex-col py-14">
+        <div className="flex flex-col-reverse gap-4 md:flex-row md:items-center justify-between mb-4">
+          <h1 className="w-full font-semibold text-3xl sm:text-4xl lg:text-5xl">
+            Squarespace
+          </h1>
+          <div className="flex justify-end">
+            <DateRangePicker
+              enableYearNavigation
+              value={dateRange}
+              onChange={(range) => setDateRange(range)}
+              presets={defaultPresets}
+              className="w-60"
+            />
+          </div>
+        </div>
+
+        {/* DATA TABLE OR LOADING */}
+        {isPending ? (
+          <div className="flex justify-center items-center">
+            <Loading />
+          </div>
+        ) : error ? (
+          <div className="flex justify-center items-center p-8">
+            <p className="text-red-600">
+              Failed to load Squarespace data: {error.message}
+            </p>
+          </div>
+        ) : (
+          <DataTable
+            columns={squarespaceColumns}
+            data={orders}
+            tableType="squarespaceData"
+            pageSize={10}
+          />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default SquarespaceDashboardPage;

--- a/react-app/src/pages/SquarespaceDashboardPage/SquarespaceTableColumns.tsx
+++ b/react-app/src/pages/SquarespaceDashboardPage/SquarespaceTableColumns.tsx
@@ -1,0 +1,64 @@
+import { ColumnDef } from "@tanstack/react-table";
+import ColumnSortButton from "@/components/DataTable/ColumnSortButton";
+
+export type SquarespaceOrder = {
+  name: string;
+  email: string;
+  item: string;
+  cost: number;
+  date: string;
+  channel: string;
+};
+
+export const squarespaceColumns: ColumnDef<SquarespaceOrder>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => {
+      return <ColumnSortButton column={column}>Name</ColumnSortButton>;
+    },
+  },
+  {
+    accessorKey: "email",
+    header: ({ column }) => {
+      return <ColumnSortButton column={column}>Email</ColumnSortButton>;
+    },
+  },
+  {
+    accessorKey: "item",
+    header: ({ column }) => {
+      return <ColumnSortButton column={column}>Item</ColumnSortButton>;
+    },
+  },
+  {
+    accessorKey: "cost",
+    header: ({ column }) => {
+      return <ColumnSortButton column={column}>Cost</ColumnSortButton>;
+    },
+    cell: ({ row }) => {
+      const amount = parseFloat(row.getValue("cost"));
+      const formatted = new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+      }).format(amount);
+
+      return formatted;
+    },
+  },
+  {
+    accessorKey: "date",
+    header: ({ column }) => {
+      return <ColumnSortButton column={column}>Date</ColumnSortButton>;
+    },
+    cell: ({ getValue }) =>
+      Intl.DateTimeFormat("en-us", {
+        dateStyle: "short",
+        timeStyle: "short",
+      }).format(new Date(getValue() as string)),
+  },
+  {
+    accessorKey: "channel",
+    header: ({ column }) => {
+      return <ColumnSortButton column={column}>Channel</ColumnSortButton>;
+    },
+  },
+];

--- a/react-app/src/pages/SquarespaceDashboardPage/SquarespaceTableColumns.tsx
+++ b/react-app/src/pages/SquarespaceDashboardPage/SquarespaceTableColumns.tsx
@@ -8,6 +8,7 @@ export type SquarespaceOrder = {
   cost: number;
   date: string;
   channel: string;
+  id: string | undefined;
 };
 
 export const squarespaceColumns: ColumnDef<SquarespaceOrder>[] = [

--- a/react-app/src/queries/squarespaceQueries.ts
+++ b/react-app/src/queries/squarespaceQueries.ts
@@ -2,6 +2,15 @@ import { Client } from "@/types/ClientType";
 import { createQueryKeys } from "@lukemorales/query-key-factory";
 
 export const squarespaceQueries = createQueryKeys("squarespaceData", {
+  orders: (startDate?: string, endDate?: string) => [
+    "orders",
+    startDate,
+    endDate,
+  ],
   ordersForClient: (email: string) => ["orders", "client", email],
-  ordersForClients: (clients: Client[]) => ["orders", "clients", clients.map(c => c.email)],
+  ordersForClients: (clients: Client[]) => [
+    "orders",
+    "clients",
+    clients.map((c) => c.email),
+  ],
 });

--- a/react-app/src/services/squarespaceService.ts
+++ b/react-app/src/services/squarespaceService.ts
@@ -139,9 +139,12 @@ export async function getAllSquarespaceOrdersInRangeWithProfiles(
     ),
   );
 
-  const profileByEmail = new Map(
-    profiles.filter((p) => p !== null).map((p) => [p.email, p]),
-  );
+  const profileByEmail = new Map<string, SquarespaceProfile>();
+  for (const p of profiles) {
+    if (p?.email) {
+      profileByEmail.set(p.email, p);
+    }
+  }
 
   return orders.map((order) => ({
     ...order,

--- a/react-app/src/services/squarespaceService.ts
+++ b/react-app/src/services/squarespaceService.ts
@@ -102,7 +102,7 @@ export async function getAllSquarespaceOrdersInRange(
 export async function getSquarespaceCustomerByEmail(email: string) {
   const axios = await axiosClient();
   const resp = await axios.get<SquarespaceProfile>(
-    `/squarespace/profile?email=${email}`,
+    `/squarespace/profile?email=${encodeURIComponent(email)}`,
   );
 
   return resp.data;

--- a/react-app/src/services/squarespaceService.ts
+++ b/react-app/src/services/squarespaceService.ts
@@ -138,8 +138,9 @@ export async function getAllSquarespaceOrdersInRangeWithProfiles(
       getSquarespaceCustomerByEmail(email).catch(() => null),
     ),
   );
+
   const profileByEmail = new Map(
-    profiles.filter(Boolean).map((p) => [p.email, p]),
+    profiles.filter((p) => p !== null).map((p) => [p.email, p]),
   );
 
   return orders.map((order) => ({

--- a/react-app/src/services/squarespaceService.ts
+++ b/react-app/src/services/squarespaceService.ts
@@ -1,89 +1,109 @@
-import { axiosClient } from "@/lib/utils"
+import { axiosClient } from "@/lib/utils";
 
 export type SquarespaceOrder = {
-  id: string,
-  orderNumber: string,
-  createdOn: string,
-  modifiedOn: string,
-  channel: string,
-  fulfillmentStatus: string,
-  customerEmail?: string,
-  customerId?: string,
+  id: string;
+  orderNumber: string;
+  createdOn: string;
+  modifiedOn: string;
+  channel: string;
+  fulfillmentStatus: string;
+  customerEmail?: string;
+  customerId?: string;
   lineItems: {
-    id: string,
-    variantId: string,
-    sku: string,
-    productId: string,
-    productName: string,
-    quantity: number,
+    id: string;
+    variantId: string;
+    sku: string;
+    productId: string;
+    productName: string;
+    quantity: number;
     unitPricePaid: {
-      value: string,
-      currency: string
-    },
+      value: string;
+      currency: string;
+    };
     variantOptions: [
       {
-        optionName: string,
-        value: string
-      }
-    ],
-    imageUrl: string,
-    lineItemType: string
-  }[],
+        optionName: string;
+        value: string;
+      },
+    ];
+    imageUrl: string;
+    lineItemType: string;
+  }[];
   subtotal: {
-    value: string,
-    currency: string
-  },
+    value: string;
+    currency: string;
+  };
   shippingTotal: {
-    value: string
-    currency: string
-  },
+    value: string;
+    currency: string;
+  };
   discountTotal: {
-    value: string,
-    currency: string
-  },
+    value: string;
+    currency: string;
+  };
   taxTotal: {
-    value: string,
-    currency: string
-  },
+    value: string;
+    currency: string;
+  };
   refundedTotal: {
-    value: string,
-    currency: string
-  },
+    value: string;
+    currency: string;
+  };
   grandTotal: {
-    value: string,
-    currency: string
-  },
-  channelName: string,
-  externalOrderReference: string,
-  fulfilledOn: string,
-  priceTaxInterpretation: string
-}
+    value: string;
+    currency: string;
+  };
+  channelName: string;
+  externalOrderReference: string;
+  fulfilledOn: string;
+  priceTaxInterpretation: string;
+};
 
 type SquarespaceProfile = {
-  id: string,
-  firstName?: string,
-  lastName?: string,
-  email?: string,
-  isCustomer: boolean,
-  createdOn: string,
+  id: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  isCustomer: boolean;
+  createdOn: string;
   transactionSummary: {
-    firstOrderSubmittedOn: string,
-    lastOrderSubmittedOn: string,
-    orderCount: number,
+    firstOrderSubmittedOn: string;
+    lastOrderSubmittedOn: string;
+    orderCount: number;
+  };
+};
+
+export type SquarespaceOrderWithProfile = SquarespaceOrder & {
+  customerProfile: SquarespaceProfile | null;
+};
+
+export async function getAllSquarespaceOrdersInRange(
+  startDate?: string,
+  endDate?: string,
+): Promise<SquarespaceOrder[]> {
+  try {
+    const axios = await axiosClient();
+    const params = new URLSearchParams();
+    if (startDate) params.append("startDate", startDate);
+    if (endDate) params.append("endDate", endDate);
+
+    const queryString = params.toString();
+    const url = `/squarespace/orders${queryString ? `?${queryString}` : ""}`;
+
+    const resp = await axios.get<SquarespaceOrder[]>(url);
+
+    return resp.data;
+  } catch (error) {
+    console.error("Error fetching Squarespace orders:", error);
+    throw error;
   }
-}
-
-
-export async function getAllSquarespaceOrdersInRange(startDate: string, endDate: string): Promise<SquarespaceOrder[]> {
-  const axios = await axiosClient();
-  const resp = await axios.get<SquarespaceOrder[]>(`/squarespace/orders?startDate=${startDate}&endDate=${endDate}`);
-
-  return resp.data;
 }
 
 export async function getSquarespaceCustomerByEmail(email: string) {
   const axios = await axiosClient();
-  const resp = await axios.get<SquarespaceProfile>(`/squarespace/profile?email=${email}`);
+  const resp = await axios.get<SquarespaceProfile>(
+    `/squarespace/profile?email=${email}`,
+  );
 
   return resp.data;
 }
@@ -96,7 +116,36 @@ export async function getAllSquarespaceOrdersForClientByEmail(email: string) {
 
 export async function getAllSquarespaceOrdersForClientById(id: string) {
   const axios = await axiosClient();
-  const resp = await axios.get<SquarespaceOrder[]>(`/squarespace/orders/customer/${id}`);
+  const resp = await axios.get<SquarespaceOrder[]>(
+    `/squarespace/orders/customer/${id}`,
+  );
 
   return resp.data;
+}
+
+export async function getAllSquarespaceOrdersInRangeWithProfiles(
+  startDate?: string,
+  endDate?: string,
+) {
+  const orders = await getAllSquarespaceOrdersInRange(startDate, endDate);
+
+  const emails = Array.from(
+    new Set(orders.map((order) => order.customerEmail).filter(Boolean)),
+  ) as string[];
+
+  const profiles = await Promise.all(
+    emails.map((email) =>
+      getSquarespaceCustomerByEmail(email).catch(() => null),
+    ),
+  );
+  const profileByEmail = new Map(
+    profiles.filter(Boolean).map((p) => [p.email, p]),
+  );
+
+  return orders.map((order) => ({
+    ...order,
+    customerProfile: order.customerEmail
+      ? (profileByEmail.get(order.customerEmail) ?? null)
+      : null,
+  }));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Squarespace dashboard page with desktop and mobile navigation links.
  * Date range picker to filter Squarespace orders.
  * Table view with name, email, item, cost (USD), date (localized), channel, and sorting.
  * Orders enriched with associated customer profile details.
  * Search/filter support and conditional row navigation when client data is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->